### PR TITLE
Replace pointers with channels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,36 +2,43 @@ extern crate jobsteal;
 extern crate num_cpus;
 extern crate time;
 
+use std::sync::mpsc::{channel, Sender};
+
 use jobsteal::{make_pool, Spawner};
 
-const NUM_CHILDREN: usize = 10;
+const NUM_CHILDREN: u64 = 10;
 
-fn skynet<'a, 'b>(spawner: Spawner<'a, 'b>, dst: &mut u64, num: u64, size: u64) {
+fn skynet<'a, 'b>(spawner: Spawner<'a, 'b>, dst: Sender<u64>, num: u64, size: u64) {
 	if size <= 1 {
-		*dst = num;
+		dst.send(num).unwrap();
+
 		return;
 	}
 
-	let mut dst_arr = [0; NUM_CHILDREN];
+	let (tx, rx) = channel();
 	let new_size = size / NUM_CHILDREN as u64;
+
 	spawner.scope(|scope| {
-		for (i, new_dst) in dst_arr.iter_mut().enumerate() {
-			let i = i as u64;
+		for i in 0..NUM_CHILDREN {
 			let new_num = num + i*new_size;
+			let tx      = tx.clone();
+
 			scope.recurse(move |spawner| {
-				skynet(spawner, new_dst, new_num, new_size);
+				skynet(spawner, tx, new_num, new_size);
 			});
 		}
+
 	});
 
-	*dst = dst_arr.iter().fold(0, |acc, &x| acc + x);
+	dst.send((0..NUM_CHILDREN).map(|_| rx.recv().unwrap()).fold(0, std::ops::Add::add)).unwrap();
 }
 
 fn main() {
 	let start = time::precise_time_ns();
-	let mut pool = jobsteal::make_pool(num_cpus::get()).unwrap();
+	let mut pool = make_pool(num_cpus::get()).unwrap();
+	let (tx, rx) = channel();
 
-	let mut result = 0;
-	skynet(pool.spawner(), &mut result, 0, 1000000);
-	println!("result = {}, time elapsed = {} nanoseconds", result, time::precise_time_ns() - start);
+	skynet(pool.spawner(), tx, 0, 1000000);
+
+	println!("result = {}, time elapsed = {} nanoseconds", rx.recv().unwrap(), time::precise_time_ns() - start);
 }


### PR DESCRIPTION
Since the other submissions use channels or equivalent it is a bit of a "cheat" to let Rust use pointers (even though it is can be verified by borrowck).
